### PR TITLE
SVD: use S.data for truncation while keeping S as Tensor

### DIFF
--- a/tensor_network_library/core/tensor.py
+++ b/tensor_network_library/core/tensor.py
@@ -203,7 +203,9 @@ class Tensor:
         if policy is None:
             return U, S, Vt
         
-        chi = policy.choose_bond_dim(S)
+        # Use the numeric singular values for the policy
+        s_vals = np.asarray(S.data, dtype=float)
+        chi = policy.choose_bond_dim(s_vals)
 
         U_trunc = Tensor(U.data[..., :chi])
         S_trunc = Tensor(S.data[:chi])


### PR DESCRIPTION
Keep S as Tensor in SVD while using its underlying numeric values for truncation.

Changes in this PR:
- Updated Tensor.svd so that it calls TruncationPolicy.choose_bond_dim on S.data (a 1D numpy array) while preserving the public API where U, S, and V are all Tensor objects.
- This resolves previous type mismatches when applying truncation policies while retaining the design choice of representing singular values as Tensors.

Branch: core_development
