### PR TITLE
v0.1.6: diary/roadmap updates, version bump, LOC workflow fix

### DIFF
--- a/.github/workflows/update-loc.yml
+++ b/.github/workflows/update-loc.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - main
-permissions: 
+    paths-ignore:
+      - "README.md"
+
+permissions:
   contents: write
+
 jobs:
   count-loc:
     runs-on: ubuntu-latest
@@ -15,12 +19,14 @@ jobs:
 
       - name: Count lines of code
         id: loc
+        shell: bash
         run: |
           # Count non-empty lines in tracked Python files
-          LOC=$(git ls-files '*.py' | xargs cat | sed '/^\s*$/d' | wc -l)
+          LOC=$(git ls-files '*.py' | xargs -r cat | sed '/^\s*$/d' | wc -l)
           echo "loc=$LOC" >> "$GITHUB_OUTPUT"
 
       - name: Update README with LOC
+        shell: bash
         run: |
           LOC=${{ steps.loc.outputs.loc }}
           tmpfile=$(mktemp)

--- a/DIARY.md
+++ b/DIARY.md
@@ -1,5 +1,12 @@
 # Development Diary
 
+## 2026-03-04 -- v0.1.6
+- Added state constrcutors for easy product state creation in `tensor_network_library/states/qubit_states`
+  - Added apropriate tests
+- Integrated qubit states into `mps`
+  - Added appropriate tests
+- Added classmethod that creates an MPS from a random statevector.
+
 ## 2026-03-02 -- 2026-03-03 -- v0.1.5
 - Developed `index` in order to track contractions properly.
 - Updated `tensor` to accomodate the new indexing method.

--- a/DIARY.md
+++ b/DIARY.md
@@ -1,11 +1,12 @@
 # Development Diary
 
 ## 2026-03-04 -- v0.1.6
-- Added state constrcutors for easy product state creation in `tensor_network_library/states/qubit_states`
-  - Added apropriate tests
-- Integrated qubit states into `mps`
-  - Added appropriate tests
-- Added classmethod that creates an MPS from a random statevector.
+- Added qubit-state constructors and parsers in `tensor_network_library/states/qubit_states` (including Pauli eigenstates, Hadamard eigenstates, equator states, and magic state families).
+- Added user-facing helpers to list and print available qubit-state labels.
+- Integrated qubit states into `MPS` via `MPS.from_qubit_labels(...)` for easy product-state initialization.
+- Added `MPS.from_state_vector(...)` constructor using successive SVD with `TruncationPolicy` support (cutoff, `max_bond_dim`, and `strict` behavior), plus a compatibility alias `from_statevector`.
+- Added/extended pytest coverage for the new state helpers and MPS constructors.
+- Fixed CI LOC injection by adding README markers expected by the `update-loc` workflow.
 
 ## 2026-03-02 -- 2026-03-03 -- v0.1.5
 - Developed `index` in order to track contractions properly.
@@ -46,5 +47,4 @@
   - `test_mpo.py` for MPO identity, dense conversion, and apply consistency.
 - Configured GitHub Actions CI (`.github/workflows/tests.yml`) to run `pytest` on pushes and PRs.
 - Created `core_development` branch and merged the initial core TN layer into `main` via PR #1.
-
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 
 ## Lines of code
 
-_Last updated automatically by CI:_ 
+_Last updated automatically by CI:_
+
+<!-- LOC-AUTO-START -->
 685
+<!-- LOC-AUTO-END -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,12 +16,12 @@
 ## v0.2 – State helpers and environments
 
 - [ ] Add helper functions for common quantum states:
-  - [ ] `zero_state(L, d=2)` and `basis_state(L, bits, d=2)` returning MPS.
+  - [x] `zero_state(L, d=2)` and `basis_state(L, bits, d=2)` returning MPS.
   - [ ] Simple entangled states for tests (e.g. Bell pair, GHZ).
 - [ ] Introduce an environment/config object:
   - [ ] System type (e.g. spin-1/2, spin-1, qudit).
   - [ ] System size `L`, local dimension `d`, boundary conditions.
-  - [ ] Bond dimension configuration (static and simple dynamic schedule).
+  - [x] Bond dimension configuration (static and simple dynamic schedule).
 - [ ] Tests validating shapes, norms, and basic config invariants.
 
 ## v0.3 – TEBD / iTEBD scaffolding

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,20 +8,20 @@
 - [x] `MPO` class with identity, apply-to-MPS, and dense conversion.
 - [x] Unit tests for Tensor, MPS, and MPO.
 - [x] GitHub Actions CI running `pytest` on pushes and PRs.
-- [ ] Add left- right- and mied canonicalizations.
-- [x] QR decompositionmethod in tensor.
-- [x] SVD decomposition withut truncation.
-- [ ] SVD decomposition with options for the environment.
+- [ ] Add left-, right-, and mixed-canonicalization routines.
+- [x] QR decomposition method in `Tensor`.
+- [x] SVD decomposition without truncation.
+- [x] SVD-based MPS constructor from dense statevector with `TruncationPolicy` (cutoff + `max_bond_dim`).
 
 ## v0.2 – State helpers and environments
 
-- [ ] Add helper functions for common quantum states:
-  - [x] `zero_state(L, d=2)` and `basis_state(L, bits, d=2)` returning MPS.
-  - [ ] Simple entangled states for tests (e.g. Bell pair, GHZ).
+- [x] Add helper functions for common qubit states (`tensor_network_library/states/qubit_states`).
+- [x] Add an MPS initializer from qubit labels (`MPS.from_qubit_labels`).
+- [ ] Add simple entangled states for tests (e.g. Bell pair, GHZ).
 - [ ] Introduce an environment/config object:
   - [ ] System type (e.g. spin-1/2, spin-1, qudit).
   - [ ] System size `L`, local dimension `d`, boundary conditions.
-  - [x] Bond dimension configuration (static and simple dynamic schedule).
+  - [ ] Truncation policy presets/schedules (e.g. per-sweep bond schedules).
 - [ ] Tests validating shapes, norms, and basic config invariants.
 
 ## v0.3 – TEBD / iTEBD scaffolding
@@ -33,11 +33,16 @@
 
 ## v0.4 – DMRG building blocks
 
+- [ ] Operator helpers similar to `qubit_states` (single-site ops like X/Y/Z; two-site couplings; utilities to assemble Hamiltonians).
+- [ ] MPO builders for standard 1D models (e.g. transverse-field Ising, Heisenberg).
+- [ ] Canonical forms + environment tensors (left/right blocks) for sweeps.
 - [ ] Implement effective Hamiltonian construction for a single site / two sites.
 - [ ] Integrate a basic eigensolver (SciPy) for local ground-state updates.
-- [ ] Add simple 1D model (e.g. transverse-field Ising) as an MPO.
-- [ ] Test DMRG ground state energies against exact diagonalization for small systems.
-- [ ] Push for a stable v1.0.0 version with TEBD, DMRG, iTEBD
+- [ ] Test DMRG ground-state energies against exact diagonalization for small systems.
+
+## v1.0 – Stable algorithms
+
+- [ ] TEBD + DMRG + iTEBD in a stable public API.
 
 ## v1.5 – Advanced features (AQA, QML, QEC, ...)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quantum-simulation-lab"
-version = "0.0.1"
+version = "0.1.6"
 requires-python = ">=3.14.0"
 dependencies = [
     "numpy",

--- a/tensor_network_library/core/mpo.py
+++ b/tensor_network_library/core/mpo.py
@@ -1,9 +1,16 @@
 """Matrix Product Operator (MPO) implementation."""
 
+from __future__ import annotations
+
 import numpy as np
+from numpy.typing import NDArray
+
 from typing import List
 from .tensor import Tensor
+from .index import Index
 from .mps import MPS
+
+ComplexArray = NDArray[np.complex128]
 
 class MPO:
     """

--- a/tensor_network_library/core/mps.py
+++ b/tensor_network_library/core/mps.py
@@ -222,6 +222,137 @@ class MPS:
 
         local_vecs = [np.asarray(v, dtype=dtype) for v in qubit_states(labels)]
         return cls.from_local_states(local_states=local_vecs, name=name, dtype=dtype)
+    
+
+    @classmethod
+    def from_statevector(cls,
+                          psi: np.ndarray,
+                          physical_dims: PhysDims = 2,
+                          *,
+                          name: str = "MPS",
+                          truncation: TruncationPolicy | None = None,
+                          absorb: str = "right",        #"right", "left", "sqrt"
+                          normalize: bool = True,
+                          dtype: np.dtype = np.complex128,
+                          ) -> "MPS":
+        """
+        Build an MPS from a dense statevector via succesive SVD.
+
+        If truncation is None: keep full rank at each cut (exact MPS)
+        If truncation is set: keep truncation.choose_bond_dim(S) at each cut.
+        """        
+
+        vec = np.asarray(psi, dtype = dtype).reshape(-1)
+        if vec.ndim != 1:
+            raise ValueError("Psi must be a 1D statevector")
+        if vec.size == 0:
+            raise ValueError("psi must be non-empty")
+        
+        n = np.linalg.norm(vec)
+        if n == 0:
+            raise ValueError("psi must be nonzero")
+        if normalize:
+            vec = vec / n
+
+        # Resolve physical dimension
+        if isinstance(physical_dims, int):
+            d = int(physical_dims)
+            if d <= 0:
+                raise ValueError("physical_dims must be positive")
+
+            n = vec.shape[0]
+            L = 0
+            tmp = n
+            while tmp > 1 and (tmp % d == 0):
+                tmp //= d
+                L += 1
+            if d**L != n:
+                raise ValueError("len(psi) is not a power of physical_dims")
+            dims = [d] * L
+        else:
+            dims = [int(x) for x in physical_dims]
+            if any(x <= 0 for x in dims):
+                raise ValueError("All physical dimensions must be positive")
+            n = int(np.prod(dims))
+            if vec.shape[0] != n:
+                raise ValueError("len(psi) does not match product of physical_dims")
+            
+        L = len(dims)
+
+        if L <= 0:
+            raise ValueError("Cannot build an MPS with L = 0")
+
+        absorb = str(absorb).lower()
+        if absorb not in {"right", "left", "sqrt"}:
+            raise ValueError("absorb must be one of {'right', 'left', 'sqrt'}")
+        
+        def choose_chi(S: np.ndarray) -> int:
+            chi_full = int(S.shape[0])
+            if truncation is None:
+                return chi_full
+            chi = int(truncation.choose_bond_dim(S))
+            if chi <= 0:
+                raise ValueError(
+                    "TruncationPolicy chose chi=0 (cutoff too large or state near-zero on this cut)."
+                )
+            return min(chi, chi_full)
+        
+
+        # Build indices
+        phys_ix = [
+            Index(dim=dims[i], name=f"{name}_phys_{i}", tags=frozenset({"phys", f"i={i}"}))
+            for i in range(L)
+        ]
+        bonds = [Index(dim=1, name=f"{name}_bond_0", tags=frozenset({"bond", "b=0"}))]
+
+        tensors: List[Tensor] = []
+        rem = vec
+        chi_left = 1
+
+        for i in range(L - 1):
+            di = dims[i]
+            rem = rem.reshape(chi_left * di, -1)
+
+            # SVD: singular values are sorted descending. [web:508]
+            U, S, Vh = np.linalg.svd(rem, full_matrices=False)
+
+            chi = choose_chi(S)
+            U = U[:, :chi]
+            S = S[:chi]
+            Vh = Vh[:chi, :]
+
+            bond = Index(dim=chi, name=f"{name}_bond_{i+1}", tags=frozenset({"bond", f"b={i+1}"}))
+            bonds.append(bond)
+
+            if absorb == "right":
+                A = U.reshape(chi_left, di, chi)
+                rem = (S[:, None] * Vh)              # diag(S) @ Vh
+            elif absorb == "left":
+                A = (U * S[None, :]).reshape(chi_left, di, chi)  # U @ diag(S)
+                rem = Vh
+            else:  # "sqrt"
+                s = np.sqrt(S)
+                A = (U * s[None, :]).reshape(chi_left, di, chi)
+                rem = (s[:, None] * Vh)
+
+            tensors.append(Tensor(A.astype(dtype, copy=False), indices=[bonds[i], phys_ix[i], bond]))
+            chi_left = chi
+
+        # Last site
+        last_d = dims[-1]
+        rem = rem.reshape(chi_left, last_d)
+        bonds.append(Index(dim=1, name=f"{name}_bond_{L}", tags=frozenset({"bond", f"b={L}"})))
+
+        A_last = rem.reshape(chi_left, last_d, 1)
+        tensors.append(
+            Tensor(A_last.astype(dtype, copy=False), indices=[bonds[L - 1], phys_ix[L - 1], bonds[L]])
+        )
+
+        mps = cls.from_tensors(tensors=tensors, name=name)
+        if normalize:
+            mps.normalize()
+        return mps
+            
 
     # -------------------------
     # Internal helpers

--- a/tensor_network_library/core/mps.py
+++ b/tensor_network_library/core/mps.py
@@ -299,10 +299,7 @@ class MPS:
         
 
         # Build indices
-        phys_ix = [
-            Index(dim=dims[i], name=f"{name}_phys_{i}", tags=frozenset({"phys", f"i={i}"}))
-            for i in range(L)
-        ]
+        phys_ix = [Index(dim=dims[i], name=f"{name}_phys_{i}", tags=frozenset({"phys", f"i={i}"})) for i in range(L)]
         bonds = [Index(dim=1, name=f"{name}_bond_0", tags=frozenset({"bond", "b=0"}))]
 
         tensors: List[Tensor] = []

--- a/tensor_network_library/core/mps.py
+++ b/tensor_network_library/core/mps.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List, Union, Sequence
 import numpy as np
 
 from .tensor import Tensor
@@ -203,6 +203,25 @@ class MPS:
             mps.tensors[i].data[0, :, 0] = v
 
         return mps
+
+    
+    @classmethod
+    def from_qubit_labels(cls,
+                          labels: Sequence[str],
+                          *,
+                          name: str = "MPS",
+                          dtype: np.dtype = np.complex128
+                          ) -> "MPS":
+        """
+        Build a product-state MPS from 1-qubit labels like:
+        ["0", "+", "i", "t3", "h7", "phi=pi/4"].
+        """
+
+        # Local import to avoid making core depend on "states" at import time
+        from tensor_network_library.states.qubit_states import qubit_states
+
+        local_vecs = [np.asarray(v, dtype=dtype) for v in qubit_states(labels)]
+        return cls.from_local_states(local_states=local_vecs, name=name, dtype=dtype)
 
     # -------------------------
     # Internal helpers

--- a/tensor_network_library/states/qubit_states.py
+++ b/tensor_network_library/states/qubit_states.py
@@ -7,6 +7,7 @@ import numpy as np
 import warnings
 import re
 
+
 def _norm(v: np.ndarray) -> np.ndarray:
     """
     Helper.
@@ -22,6 +23,7 @@ def _norm(v: np.ndarray) -> np.ndarray:
         warnings.warn("State vector norm is very small.", stacklevel=2)
     
     return v / n
+
 
 def _state_from_bloch(a: np.ndarray) -> np.ndarray:
     """
@@ -50,6 +52,7 @@ def _state_from_bloch(a: np.ndarray) -> np.ndarray:
     v = np.array([np.cos(theta / 2.0), np.exp(1j * phi) * np.sin(theta / 2.0)], dtype=np.complex128)
 
     return _norm(v)
+
 
 def _parse_angle(expr: str) -> float:
     """
@@ -144,6 +147,7 @@ def qubit_state(label: str) -> np.ndarray:
 
     raise ValueError(f"Unknown qubit state label: {label!r}")
     
+
 def qubit_pauli_eigenstates(key: str) -> np.ndarray :
     if key == "x+":
         return _norm(np.array([1.0, 1.0], dtype = np.complex128))
@@ -160,6 +164,7 @@ def qubit_pauli_eigenstates(key: str) -> np.ndarray :
     
     raise ValueError(f"Unknown qubit pauli egienstate: {key}")
 
+
 def qubit_hadamard_eigenstates(sign: str = '+') -> np.ndarray:
     # Eigenstates of H with eigenvalues plus or minus 1
     # |H+> = cos(pi/8)|0> + sin(pi/8)|1>
@@ -173,10 +178,12 @@ def qubit_hadamard_eigenstates(sign: str = '+') -> np.ndarray:
         return _norm(np.array([s, -c], dtype=np.complex128))
     raise ValueError(f"Unknown Hadamard sign: {sign!r}")
     
+
 def equator_state(phi: float) -> np.ndarray:
     # (|0> + e^{i phi} |1>) / sqrt(2)
     return _norm(np.array([1.0, np.exp(1j * phi)], dtype=np.complex128))
     
+
 def qubit_t_type_magic_states(k: int) -> np.ndarray:
     """
     8 T-type states: Bloch vectors at cube vertices (±1,±1,±1)/sqrt(3). [web:281]
@@ -191,6 +198,7 @@ def qubit_t_type_magic_states(k: int) -> np.ndarray:
 
     a = np.array([sx, sy, sz], dtype=float) / np.sqrt(3.0)
     return _state_from_bloch(a)
+
 
 def qubit_h_type_magic_states(k: int) -> np.ndarray:
     """
@@ -221,11 +229,40 @@ def qubit_h_type_magic_states(k: int) -> np.ndarray:
         raise ValueError(f"H-type index k must be in {{0,...,{len(vecs)-1}}}.")
     return _state_from_bloch(vecs[k])
 
+
 def qubit_max_magic_states(k: int) -> np.ndarray:
     """
     Alias for the 8 maximal-magic (T-type) qubit states.
     """
     return qubit_t_type_magic_states(k)
 
+
 def qubit_states(labels: Iterable[str]) -> list[np.ndarray]:
     return [qubit_state(x) for x in labels]
+
+
+# Put near the bottom of the module
+def available_qubit_state_labels() -> list[str]:
+    labels = []
+
+    # Pauli / common aliases
+    labels += ["0", "1", "+", "-", "i", "-i", "I", "-I"]
+
+    # Hadamard eigenstates (and your "H" alias)
+    labels += ["h+", "h-", "H+", "H-", "H"]
+
+    # T-type and H-type indexed families
+    labels += [f"t{k}" for k in range(8)]
+    labels += [f"h{k}" for k in range(12)]
+
+    # Equator syntax (examples, since it's infinite)
+    labels += ["phi=pi/4", "phi:pi/7"]
+
+    return labels
+
+
+def print_available_qubit_states() -> None:
+    labs = available_qubit_state_labels()
+    print("Available qubit state labels:")
+    for s in labs:
+        print(f"  {s}")

--- a/tensor_network_library/states/qubit_states.py
+++ b/tensor_network_library/states/qubit_states.py
@@ -243,7 +243,7 @@ def qubit_states(labels: Iterable[str]) -> list[np.ndarray]:
 
 # Put near the bottom of the module
 def available_qubit_state_labels() -> list[str]:
-    labels = []
+    labels:list[str] = []
 
     # Pauli / common aliases
     labels += ["0", "1", "+", "-", "i", "-i", "I", "-I"]

--- a/tests/core/test_mps.py
+++ b/tests/core/test_mps.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from tensor_network_library.core.mps import MPS
 from tensor_network_library.core.index import Index
 from tensor_network_library.core.tensor import Tensor
+from tensor_network_library.core.policy import TruncationPolicy
 from tensor_network_library.states.qubit_states import qubit_states
 
 def _kron_list(vecs: list[np.ndarray]) -> np.ndarray:
@@ -349,3 +350,156 @@ def test_from_qubit_labels_length_and_bond_dims():
     assert len(mps) == len(labels)
     assert mps.bond_dims == [1] * (len(labels) + 1)
     assert mps.physical_dims == [2] * len(labels)
+
+
+def _global_phase_equal(v: np.ndarray, w: np.ndarray, atol: float = 1e-12) -> bool:
+    v = np.asarray(v, dtype=np.complex128).reshape(-1)
+    w = np.asarray(w, dtype=np.complex128).reshape(-1)
+    if v.shape != w.shape:
+        return False
+    nv = np.linalg.norm(v)
+    nw = np.linalg.norm(w)
+    if nv == 0 or nw == 0:
+        return False
+    v = v / nv
+    w = w / nw
+
+    idx = int(np.argmax(np.abs(w)))
+    if np.abs(w[idx]) < atol:
+        return np.allclose(v, w, atol=atol, rtol=0)
+
+    phase = v[idx] / w[idx]
+    return np.allclose(v, phase * w, atol=atol, rtol=0)
+
+
+def _kron_all(vecs):
+    out = np.array([1.0 + 0.0j], dtype=np.complex128)
+    for v in vecs:
+        out = np.kron(out, np.asarray(v, dtype=np.complex128).reshape(-1))
+    return out
+
+
+# -------------------------
+# from_qubit_labels tests
+# -------------------------
+
+def test_from_qubit_labels_matches_dense_kron():
+    labels = ["0", "+", "i", "t3", "h7", "phi=pi/4"]
+    mps = MPS.from_qubit_labels(labels, name="psi")
+    dense = mps.to_dense()
+
+    expected = _kron_all(qubit_states(labels))
+    assert dense.shape == expected.shape
+    assert np.allclose(dense, expected, atol=1e-12, rtol=0)
+
+
+def test_from_qubit_labels_product_mps_has_bond_dim_1():
+    labels = ["0", "t0", "h0", "phi=pi/7"]
+    mps = MPS.from_qubit_labels(labels)
+    assert mps.bond_dims == [1] * (len(labels) + 1)
+    assert mps.physical_dims == [2] * len(labels)
+
+
+def test_from_qubit_labels_invalid_label_raises():
+    with pytest.raises(ValueError):
+        MPS.from_qubit_labels(["0", "not_a_state"])
+
+
+def test_from_qubit_labels_dtype_is_respected():
+    labels = ["0", "t0", "h0"]
+    mps = MPS.from_qubit_labels(labels, dtype=np.complex64)
+    dense = mps.to_dense()
+    assert dense.dtype == np.complex64
+
+
+# -------------------------
+# from_statevector tests
+# -------------------------
+
+def test_from_statevector_exact_roundtrip_up_to_global_phase():
+    rng = np.random.default_rng(0)
+    L = 5
+    psi = rng.normal(size=2**L) + 1j * rng.normal(size=2**L)
+    psi = psi / np.linalg.norm(psi)
+
+    mps = MPS.from_statevector(psi, physical_dims=2, truncation=None, name="svd_exact")
+    dense = mps.to_dense()
+
+    assert dense.shape == psi.shape
+    assert _global_phase_equal(dense, psi, atol=1e-10)
+    assert np.isclose(mps.norm(), 1.0, atol=1e-10, rtol=0)
+
+
+@pytest.mark.parametrize("absorb", ["right", "left", "sqrt"])
+def test_from_statevector_absorb_variants_agree(absorb):
+    rng = np.random.default_rng(1)
+    L = 4
+    psi = rng.normal(size=2**L) + 1j * rng.normal(size=2**L)
+    psi = psi / np.linalg.norm(psi)
+
+    mps = MPS.from_statevector(psi, physical_dims=2, truncation=None, absorb=absorb, name=f"abs_{absorb}")
+    dense = mps.to_dense()
+    assert _global_phase_equal(dense, psi, atol=1e-10)
+
+
+def test_from_statevector_with_dim_list():
+    rng = np.random.default_rng(2)
+    dims = [2, 3, 2]
+    n = int(np.prod(dims))
+    psi = rng.normal(size=n) + 1j * rng.normal(size=n)
+    psi = psi / np.linalg.norm(psi)
+
+    mps = MPS.from_statevector(psi, physical_dims=dims, truncation=None, name="hetero")
+    dense = mps.to_dense()
+    assert dense.shape == psi.shape
+    assert _global_phase_equal(dense, psi, atol=1e-10)
+
+
+def test_from_statevector_wrong_length_raises():
+    psi = np.ones(10, dtype=np.complex128)  # not a power of 2
+    with pytest.raises(ValueError):
+        MPS.from_statevector(psi, physical_dims=2)
+
+
+def test_from_statevector_truncation_respects_max_bond_dim():
+    rng = np.random.default_rng(3)
+    L = 8
+    psi = rng.normal(size=2**L) + 1j * rng.normal(size=2**L)
+    psi = psi / np.linalg.norm(psi)
+
+    policy = TruncationPolicy(max_bond_dim=4, cutoff=0.0, strict=False)
+    mps = MPS.from_statevector(psi, physical_dims=2, truncation=policy, name="trunc")
+
+    assert max(mps.bond_dims) <= policy.max_bond_dim
+    assert np.isclose(mps.norm(), 1.0, atol=1e-10, rtol=0)
+
+
+def test_from_statevector_strict_policy_raises_if_needed_more_than_max():
+    # Construct a state whose first cut has 4 equal nonzero singular values:
+    # |psi> = (1/2) * sum_{a=0..3} |a>_left |a>_right, with left/right being 2 qubits each.
+    psi_mat = np.eye(4, dtype=np.complex128) / 2.0  # Frobenius norm 1 -> state norm 1
+    psi = psi_mat.reshape(-1)
+
+    # cutoff=0 keeps all nonzero singular values (4), but max_bond_dim=2 => should raise in strict mode.
+    policy = TruncationPolicy(max_bond_dim=2, cutoff=0.0, strict=True)
+
+    with pytest.raises(ValueError):
+        MPS.from_statevector(psi, physical_dims=2, truncation=policy, name="strict_fail")
+
+
+def test_from_statevector_normalize_flag_controls_scaling():
+    rng = np.random.default_rng(4)
+    L = 4
+    psi = rng.normal(size=2**L) + 1j * rng.normal(size=2**L)
+    psi = psi / np.linalg.norm(psi)
+
+    scale = 3.7
+    psi2 = scale * psi
+
+    mps_normed = MPS.from_statevector(psi2, physical_dims=2, truncation=None, normalize=True, name="normed")
+    assert np.isclose(mps_normed.norm(), 1.0, atol=1e-10, rtol=0)
+
+    mps_raw = MPS.from_statevector(psi2, physical_dims=2, truncation=None, normalize=False, name="raw")
+    dense_raw = mps_raw.to_dense()
+    assert _global_phase_equal(dense_raw, psi2, atol=1e-10)
+    assert np.isclose(mps_raw.norm(), np.linalg.norm(psi2), atol=1e-8, rtol=1e-8)

--- a/tests/core/test_mps.py
+++ b/tests/core/test_mps.py
@@ -9,9 +9,16 @@ from types import SimpleNamespace
 from tensor_network_library.core.mps import MPS
 from tensor_network_library.core.index import Index
 from tensor_network_library.core.tensor import Tensor
-
+from tensor_network_library.states.qubit_states import qubit_states
 
 def _kron_list(vecs: list[np.ndarray]) -> np.ndarray:
+    out = np.array([1.0 + 0.0j], dtype=np.complex128)
+    for v in vecs:
+        out = np.kron(out, np.asarray(v, dtype=np.complex128).reshape(-1))
+    return out
+
+
+def _kron_all(vecs):
     out = np.array([1.0 + 0.0j], dtype=np.complex128)
     for v in vecs:
         out = np.kron(out, np.asarray(v, dtype=np.complex128).reshape(-1))
@@ -303,3 +310,42 @@ def test_initialize_entangled_bell_state_manual_bond_dim_2():
     expected = (np.kron([1, 0], [1, 0]) + np.kron([0, 1], [0, 1])).astype(np.complex128) / np.sqrt(2.0)
     np.testing.assert_allclose(mps.to_dense(), expected, atol=1e-12, rtol=1e-12)
     assert abs(mps.norm() - 1.0) < 1e-12
+
+
+def test_from_qubit_labels_matches_dense_kron():
+    labels = ["0", "+", "i", "t3", "h7", "phi=pi/4"]
+    mps = MPS.from_qubit_labels(labels, name="psi")
+
+    dense = mps.to_dense()
+    expected = _kron_all(qubit_states(labels))
+
+    assert dense.shape == expected.shape
+    assert np.allclose(dense, expected, atol=1e-12, rtol=0)
+
+
+def test_from_qubit_labels_norm_is_product_of_local_norms():
+    # from_local_states does not normalize the local vectors; it inserts them verbatim.
+    # qubit_states() returns normalized vectors, so the MPS norm should be 1.
+    labels = ["t0", "h0", "+", "1"]
+    mps = MPS.from_qubit_labels(labels)
+    assert np.isclose(mps.norm(), 1.0, atol=1e-12, rtol=0)
+
+
+def test_from_qubit_labels_dtype_is_respected():
+    labels = ["0", "t0", "h0"]
+    mps = MPS.from_qubit_labels(labels, dtype=np.complex64)
+    dense = mps.to_dense()
+    assert dense.dtype == np.complex64
+
+
+def test_from_qubit_labels_invalid_label_raises():
+    with pytest.raises(ValueError):
+        MPS.from_qubit_labels(["0", "definitely_not_a_state"])
+
+
+def test_from_qubit_labels_length_and_bond_dims():
+    labels = ["0", "+", "t0", "h0", "phi=pi/7"]
+    mps = MPS.from_qubit_labels(labels)
+    assert len(mps) == len(labels)
+    assert mps.bond_dims == [1] * (len(labels) + 1)
+    assert mps.physical_dims == [2] * len(labels)

--- a/tests/states/test_qubit_states.py
+++ b/tests/states/test_qubit_states.py
@@ -226,6 +226,7 @@ def test_qubit_states_batch():
         assert np.asarray(v).shape == (2,)
         assert np.isclose(np.linalg.norm(v), 1.0)
 
+
 def test_available_qubit_state_labels_are_callable():
     labels = qs.available_qubit_state_labels()
     assert isinstance(labels, list)

--- a/tests/states/test_qubit_states.py
+++ b/tests/states/test_qubit_states.py
@@ -225,3 +225,35 @@ def test_qubit_states_batch():
     for v in out:
         assert np.asarray(v).shape == (2,)
         assert np.isclose(np.linalg.norm(v), 1.0)
+
+def test_available_qubit_state_labels_are_callable():
+    labels = qs.available_qubit_state_labels()
+    assert isinstance(labels, list)
+    assert len(labels) > 0
+
+    for lab in labels:
+        v = qs.qubit_state(lab)
+        v = np.asarray(v)
+        assert v.shape == (2,)
+        assert np.iscomplexobj(v)
+        assert np.isclose(np.linalg.norm(v), 1.0)
+
+
+def test_print_available_qubit_states_lists_all_labels(capsys):
+    labels = qs.available_qubit_state_labels()
+    qs.print_available_qubit_states()
+
+    out = capsys.readouterr().out  # capture stdout [web:446][web:447]
+    assert "Available qubit state labels" in out
+
+    for lab in labels:
+        assert lab in out
+
+
+def test_available_qubit_state_labels_contains_expected_families():
+    labels = set(qs.available_qubit_state_labels())
+    assert {"0", "1", "+", "-", "i", "-i", "h+", "h-", "H"}.issubset(labels)
+    for k in range(8):
+        assert f"t{k}" in labels
+    for k in range(12):
+        assert f"h{k}" in labels


### PR DESCRIPTION
This PR prepares the `v0.1.6` snapshot for merging into `main`.

Changes:
- Bump package version to **0.1.6** in `pyproject.toml`.
- Expand `DIARY.md` (v0.1.6) to explicitly include:
  - qubit-state helper additions,
  - `MPS.from_qubit_labels`,
  - dense-statevector → MPS via SVD with `TruncationPolicy`.
- Update `ROADMAP.md` with missing milestones (operator helpers, MPO builders, sweep environments) and mark newly completed items.
- Fix LOC injection workflow:
  - Add LOC markers to README so CI can replace the number.
  - Prevent self-trigger loops by ignoring README-only pushes.
  - Make LOC counting robust when no Python files are present.

After merge: pushing to `main` will run the LOC workflow and keep the README updated automatically.