### PR TITLE
Finalize MPO implementation and add MPO test coverage

### DIFF
--- a/tensor_network_library/core/__init__.py
+++ b/tensor_network_library/core/__init__.py
@@ -1,0 +1,17 @@
+"""Tensor network library core components."""
+
+from .index import Index
+from .tensor import Tensor
+from .policy import TruncationPolicy
+from .mps import MPS
+from .env import Environment
+from .canonical import left_canonicalize
+
+__all__ = [
+    "Index",
+    "Tensor",
+    "TruncationPolicy",
+    "MPS",
+    "left_canonicalize",
+    "Environment"
+]

--- a/tensor_network_library/core/canonical.py
+++ b/tensor_network_library/core/canonical.py
@@ -44,9 +44,3 @@ def left_canonicalize(mps: MPS, policy: Optional[TruncationPolicy] = None) -> MP
         mps.tensors[i + 1] = temp
     
     return mps
-        
-        
-        
-        
-    
-    

--- a/tensor_network_library/core/env.py
+++ b/tensor_network_library/core/env.py
@@ -14,4 +14,3 @@ class Environment:
     bc: boundary_condition = "open"     # boundary condition
     max_bond_dim: int = 64              # I don't want to have a dynamical bond dimension in this build yet.
     complex_dtype: type = complex       #
-

--- a/tensor_network_library/core/index.py
+++ b/tensor_network_library/core/index.py
@@ -142,3 +142,4 @@ class Index:
                      tags = self.tags,
                      prime = self.prime,
                      id = str(uuid.uuid4()))
+    

--- a/tensor_network_library/core/mpo.py
+++ b/tensor_network_library/core/mpo.py
@@ -48,7 +48,7 @@ class MPO:
         
         Args:
             L: Chain lengths
-            d: Physical dimesnion
+            d: Physical dimension
             bond_policy:
                 - "deafult": [1, 2, 2, ..., 2, 1]
                 - int: uniform bond dimension
@@ -197,7 +197,7 @@ class MPO:
         Apply this MPO to an MPS: returns a new MPS representing: $$\hat{O}\ket{\Psi}$$
         
         The result has a "super-bond" dimension, the product of the MPS and MPO.
-        Requires identical physical dimesnions.
+        Requires identical physical dimensions.
 
         Args:
             mps: Input MPS
@@ -213,14 +213,14 @@ class MPO:
         
         if self.physical_dims != mps.physical_dims:
             raise ValueError(
-                f"Physical dimesnion mismatch: MPO has {self.physical_dims}, "
+                f"Physical dimension mismatch: MPO has {self.physical_dims}, "
                 f"MPS has {mps.physical_dims}."
             )
         
         new_tensors = []
         
         # Using Schölwock's notation here for readability:
-        for i, (W, M) in enumarate(zip(self.tensors, mps.tensors)):
+        for i, (W, M) in enumerate(zip(self.tensors, mps.tensors)):
             w_left, d_in, d_out, w_right = W.shape
             m_left, d_mps, m_right = M.shape
             
@@ -258,7 +258,8 @@ class MPO:
                 new_data, indices = [left_super_index, physical_index, right_super_index]
             ))
     
-        return MPS(new_tensors)
+        return MPS.from_tensors(new_tensors, name="MPO_applied")
+
     
 
     def to_dense(self) -> np.ndarray:

--- a/tensor_network_library/core/mpo.py
+++ b/tensor_network_library/core/mpo.py
@@ -1,11 +1,21 @@
-"""Matrix Product Operator (MPO) implementation."""
+"""
+Matrix Product Operator (MPO) implementation.
+
+Canonical axis ordering per site tensor:
+    axis 0: left bond index
+    axis 1: physical in index (row of matrix)
+    axis 2: physical out index (column of matrix)
+    axis 3: right bond index
+
+Typically the MPO represents the Hamiltonians for DMRG or TEBD.
+"""
 
 from __future__ import annotations
+from typing import List, Tuple, Optional, Callable
 
 import numpy as np
 from numpy.typing import NDArray
 
-from typing import List
 from .tensor import Tensor
 from .index import Index
 from .mps import MPS
@@ -20,117 +30,254 @@ class MPO:
     O = Σ W[0]^{s0,s0'} W[1]^{s1,s1'} ... W[L-1]^{s(L-1),s(L-1)'}
     
     Attributes:
+        L (int): Chain length.
+        d (int): Physical dimension (per site).
         tensors (List[Tensor]): List of MPO tensors. Each has shape (χ_left, d_out, d_in, χ_right).
-        num_sites (int): Number of sites.
+        bond_dims (list[int]): Bond dimensions [d_0, d_1, d_2, ..., d_L]
+        dtype (np.dtype): Data type of tensors.
     """
     
-    def __init__(self, tensors: List[Tensor]):
+    def __init__(self,
+                 L: int, 
+                 d: int,
+                 bond_policy: Union[str, int, List[int]] = "default",
+                 dtype: np.dtype = np.complex128,
+                 ):
         """
         Initialize MPO from list of tensors.
         
         Args:
-            tensors: List of MPO tensors with shape (chi_left, d_out, d_in, chi_right)
+            L: Chain lengths
+            d: Physical dimesnion
+            bond_policy:
+                - "deafult": [1, 2, 2, ..., 2, 1]
+                - int: uniform bond dimension
+                - List[int]: explicit bond dimensions (length L + 1)
+            dtype: Data type
         """
-        self.tensors = tensors
-        self.num_sites = len(tensors)
         
-        # Validate bond dimension
-        for i in range(self.num_sites - 1):
-            if tensors[i].shape[3] != tensors[i + 1].shape[0]:
-                raise ValueError(f"Bond dimension mismatch at site {i}: "
-                                 f"{tensors[i].shape[3]} != {tensors[i + 1].shape[0]}")
-                
-    def __len__(self) -> int:
-        return self.num_sites
+        self.L = L
+        self.d = d
+        self.dtype = dtype
+
+        # parse bond policy
+        if isinstance(bond_policy, list):
+            if len(bond_policy) != L + 1:
+                raise ValueError(f"bond_policy list must have length L + 1 = {L + 1}, got {len(bond_policy)}")
+            self.bond_dims = bond_policy
+        elif isinstance(bond_policy, int):
+            self.bond_dims = [1] + [bond_policy] * (L - 1) + [1]
+        elif bond_policy == "default":
+            self.bond_dims = [1] + [2] * (L - 1) + [1]
+        else:
+            raise ValueError(f"Unknown bond policy: {bond_policy}")
+
+
+        self.tensors: List[Tensor] = []
+
+        
+        # Start with identity initialization, later these will be overwritten with proper operators
+        for i in range(L):
+            D_left, D_right = self.bond_dims[i], self.bond_dims[i + 1]
+            shape = (D_left, d, d, D_right)
+            data = np.zeros(shape, dtype = dtype)
+
+            # Identity operators
+            if D_left >= 1 and D_right >= 1:
+                data[0, :, :, 0] = np.eye(d, dtype = dtype)
+            
+            # Create indices
+            left_ind = Index(dim = D_left, name = f"OL{i}", tags = {f"site_{i}"})
+            physical_in = Index(dim = d, name = f"OPI{i}", tags = {f"site_{i}", "physical_in"})
+            physical_out = Index(dim = d, name = f"OPO{i}", tags = {f"site_{i}", "physical_out"})
+            right_ind = Index(dim = D_right, name = f"OR{i}", tags = {f"site_{i}"})
+
+            self.tensors.append(
+                Tensor(data, indices = [left_ind, physical_in, physical_out, right_ind])
+                )
+  
+
+    # ------------------------
+    # Factory Methods
+    # ------------------------
+
+    @staticmethod
+    def identity_mpo(L: int,
+                     d: int, 
+                     dtype: np.dtype = np.complex128,
+                     ) -> MPO:
+        """
+        Creates an inditity MPO (trivial, do nothing operator)
+
+        Argumetns: 
+            L (int): Length of the chain.
+            d (int): physical indices.
+            dtype: Data type.
+        """
+
+        mpo = MPO(L, d, bond_policy = 1, dtype = dtype)
+        for i in range(L):
+            mpo.tensors[i].data[:, :, :, :] = 0.0
+            mpo.tensors[i].data[0, :, :, 0] = np.eye(d, dtype = dtype)
+        
+        return mpo
     
+
+    def initialize_random(self) -> None:
+        """
+        Fill all MPO tensors with random data (presering structure).
+        """
+
+        for i in range(self.L):
+            shape = self.tensors[i].shape
+            data = np.random.randn(*shape).astype(self.dtype)
+            if np.issubdtype(self.dtype, np.complexfloating):
+                data = data + 1j * np.random.randn(*shape).astype(self.dtype)
+            self.tensors[i].data = data
+
+    
+    def initialize_single_site_operator(self,
+                                        operator: np.ndarray,
+                                        site: int,
+                                        ) -> None:
+        """
+        Initialize an MPO as single-site operator at given site.
+
+        Args: 
+            operator: (d x d) operator matrix
+            site: Site index here operator acts
+        """
+
+        if operator.shape != (self.d, self.d):
+            raise ValueError(
+                f"Operator shape {operator.shape} doesn't match physical dimension ({self.d}, {self.d})"
+            )
+        
+        if not 0 <= site < self.L:
+            raise ValueError(f"Site {site} out of range [0, {self.L})")
+        
+        # Replace at target site, leave the rest of the sites as they were.
+        self.tensors[site].data[0, :, :, 0] = operator.astype(self.dtype)
+
+
+    # -------------------------
+    # Python protocol
+    # -------------------------
+
+    def __len__(self) -> int:
+        return self.L
+    
+
+    def __repr__(self) -> str:
+        shapes_str = ", ".join([str(t.shape) for t in self.tensors])
+        return f"MPO(L={self.L}, d={self.d}, shapes=[{shapes_str}])"
+    
+
+    def __str__(self) -> str:
+        return self.__repr__()
+    
+
+    def __getitem__(self, idx: int) -> Tensor:
+        return self.tensors[idx]
+    
+
+    # -------------------------
+    # Core Operations
+    # -------------------------
+
     def copy(self) -> 'MPO':
         """Creates a deep copy of an MPO."""
-        return MPO([t.copy() for t in self.tensors])
+        new_mpo = MPO(self.L, self.d, bond_policy=self.bond_dims.copy(), dtype = self.dtype)
+        new_mpo.tensors = [t.copy() for t in self.tensors]
+        return new_mpo
     
-    @property
-    def bond_dims(self) ->List[int]:
-        """Bond dimensions between sites (incuding boundaires)."""
-        dims = [self.tensors[0].shape[0]] # this is the left boundary
-        for t in self.tensors:
-            dims.append(t.shape[3])
-        return dims
-
-    @property
-    def physical_dims(self) -> List[int]:
-        """Physical dimensions of the sites."""
-        return [t.shape[1] for t in self.tensors]
-    
-    @classmethod
-    def identity(cls, num_sites: int, physical_dims: int = 2) -> 'MPO':
-        """
-        Identity operator MPO: acts as the identity operator on each local Hilbert space.
-        
-        Each tensor has shape (1, d, d, 1) with identity on the (d, d) block.
-        """
-        
-        tensors: List[Tensor] = []
-        
-        for _ in range(num_sites):
-            data = np.zeros((1, physical_dims, physical_dims, 1), dtype = np.complex128)
-            for i in range(physical_dims):
-                data[0, i, i, 0] = 1.0
-            
-            tensors.append(Tensor(data))
-        
-        return cls(tensors)
     
     def apply(self, mps: MPS) -> 'MPS':
         """
         Apply this MPO to an MPS: returns a new MPS representing: $$\hat{O}\ket{\Psi}$$
         
-        Requires identical physical dimension
+        The result has a "super-bond" dimension, the product of the MPS and MPO.
+        Requires identical physical dimesnions.
+
+        Args:
+            mps: Input MPS
+
+        Returns:
+            New MPS representing O|\psi>
         """
-        
+
         if len(self) != len(mps):
-            raise ValueError(f"Length mismatch: MPO has {len(self)} sites, MPS has {len(mps)} sites")
+            raise ValueError(
+                f"Length mismatch: MPO has {len(self)} sites, while the MPS has {len(mps)} sites."
+            )
         
         if self.physical_dims != mps.physical_dims:
-            raise ValueError(f"Physical dimension mismatch: MPO has physical dimension {self.physical_dims} while the MPS has {mps.physical_dims} physical dimension.")
+            raise ValueError(
+                f"Physical dimesnion mismatch: MPO has {self.physical_dims}, "
+                f"MPS has {mps.physical_dims}."
+            )
         
         new_tensors = []
         
         # Using Schölwock's notation here for readability:
-        for W, M in zip(self.tensors, mps.tensors):
+        for i, (W, M) in enumarate(zip(self.tensors, mps.tensors)):
             w_left, d_in, d_out, w_right = W.shape
             m_left, d_mps, m_right = M.shape
             
             if d_in != d_mps:
-                raise ValueError("Local physical dimension mismatch between MPO ({d_in}) and MPS ({d_mps})")
+                raise ValueError(
+                    "Local physical dimension mismatch between MPO ({d_in}) and MPS ({d_mps})"
+                    )
             
-            temp = np.tensordot(W.data, M.data, axes = ([1], [1]))  # The shape here is (w_left, d_out, w_right, m_left, m_right)
-            
-            temp = np.transpose(temp,(0, 3, 1, 2, 4))   # Reorder the indices to match the convention (w_left, m_left, d_out, w_right, m_right)
-            
-            # Contract w_left, m_left and w_right, m_right -> "Superindices"
+            # Contract physical indices: W[w_l, d_in, d_out, w_r] * M[m_l, d_in, m_r]
+            # axes=([1], [1]) contracts d_in of W with d_mps of M
+            temp = np.tensordot(W.data, M.data, axes=([1], [1]))
+            # Result shape: (w_left, d_out, w_right, m_left, m_right)
+
+            # Reorder to: (w_left, m_left, d_out, w_right, m_right)
+            temp = np.transpose(temp, (0, 3, 1, 2, 4))
+
+            # Merge bond dimensions into "super-bonds":
             m_super_left = w_left * m_left
             m_super_right = w_right * m_right
-            
+
             new_data = temp.reshape(m_super_left, d_out, m_super_right)
-            
-            new_tensors.append(Tensor(new_data))
-            
+
+            # creating the proper indices for the results
+            left_super_index = Index(
+                dim=m_super_left, name=f"super_L{i}", tags={f"site_{i}", "left"}
+            )
+            right_super_index = Index(
+                dim=m_super_right, name=f"super_R{i}", tags={f"site_{i}", "right"}
+            )
+
+            # Reuse physical out index from MPO
+            physical_index = W.indices[2]
+
+            new_tensors.append(Tensor(
+                new_data, indices = [left_super_index, physical_index, right_super_index]
+            ))
+    
         return MPS(new_tensors)
+    
 
     def to_dense(self) -> np.ndarray:
         """
-        Convert the MPO to a full operator matrix O of shape (d^N, d^N).
+        Convert the MPO to a full operator matrix O of shape (d^L, d^L).
 
         Contracts all internal bond indices and arranges physical indices
-        in the order (s0_in,...,sN-1_in, s0_out,...,sN-1_out), then reshapes.
-        Intended for small N for debugging.
+        in the order (s0_in,...,s(L-1)_in, s0_out,...,s(L-1)_out), then reshapes.
+
+        Intended for small L for debugging/testing only.
+
+        Returns:
+            Dense operator matrix of shape (d^L, d^L)
         """
-        N = self.num_sites
-        dims = self.physical_dims
-        # assume all dims equal for now
-        d = dims[0]
+        N = self.L
+        d = self.d
 
         # Start from first tensor: W0 (wL0, d_in0, d_out0, wR0)
-        op = self.tensors[0].data  # shape (wL, d_in, d_out, wR)
+        op = self.tensors[0].data
 
         # Sequentially contract bond indices across sites
         for t in self.tensors[1:]:
@@ -138,30 +285,41 @@ class MPO:
 
             # Contract right bond of op with left bond of next tensor
             # op: (..., wR), W_next: (wL_next, d_in_next, d_out_next, wR_next)
-            # We contract op's last axis with W_next's first axis.
             op = np.tensordot(op, W_next, axes=([-1], [0]))
-            # After this, op has shape:
-            # (wL0, d_in0, d_out0, ..., d_in_k, d_out_k, wR_k)
 
-        # Now all bonds are contracted into a single op tensor of rank 2N (plus maybe 2 boundary bonds of dim 1)
-        # Remove any singleton bond dimensions
+        # Remove singleton boundary bond dimensions
         op = np.squeeze(op)
 
-        # We need to know where the d_in and d_out indices are.
-        # For N sites, they appear as alternating (d_in0, d_out0, d_in1, d_out1, ..., d_inN-1, d_outN-1)
-
-        # Build a permutation that takes us from [d_in0, d_out0, d_in1, d_out1, ...]
-        # to [d_in0,...,d_inN-1, d_out0,...,d_outN-1]
-        axes = list(range(op.ndim))  # something like [0,1,2,3,...] with only physical dims now
-        # We assume there are exactly 2N dimensions and they are in the pattern d_in0,d_out0,...
-
-        # in_positions = [0, 2, 4, ...], out_positions = [1, 3, 5, ...]
-        in_axes = axes[0::2]
-        out_axes = axes[1::2]
+        # Now op has shape (d_in0, d_out0, d_in1, d_out1, ..., d_in(N-1), d_out(N-1))
+        # Build permutation: [d_in0,...,d_in(N-1), d_out0,...,d_out(N-1)]
+        axes = list(range(op.ndim))
+        in_axes = axes[0::2]   # [0, 2, 4, ...]
+        out_axes = axes[1::2]  # [1, 3, 5, ...]
         perm = in_axes + out_axes
 
         op_perm = np.transpose(op, perm)
 
         dim = d ** N
         return op_perm.reshape(dim, dim)
+    
+
+    # -------------------------
+    # Basic properties
+    # -------------------------
+
+    @property
+    def shape(self) -> List[Tuple[int, int, int, int]]:
+        """ Returns the shape of all MPO tensors as a list of tuples."""
+        return [t.shape for t in self.tensors]
+
+
+    @property
+    def physical_dims(self) -> List[int]:
+        """Physical dimensions of the sites."""
+        return [t.shape[1] for t in self.tensors]
+    
+    
+    
+
+    
         

--- a/tensor_network_library/core/mps.py
+++ b/tensor_network_library/core/mps.py
@@ -92,6 +92,7 @@ class MPS:
         # Create unmaterialized site tensors
         self._create_empty_tensors()
 
+
     # -------------------------
     # Constructors / factories
     # -------------------------
@@ -125,6 +126,7 @@ class MPS:
                 break
 
         return obj
+
 
     @classmethod
     def from_product_state(
@@ -161,6 +163,7 @@ class MPS:
             mps.tensors[i].data[0, s, 0] = 1.0
 
         return mps
+
 
     @classmethod
     def from_local_states(
@@ -369,6 +372,7 @@ class MPS:
             raise ValueError("All physical dimensions must be positive")
         return dims
 
+
     def _resolve_bond_dims(
         self,
         bond_policy: BondPolicy,
@@ -422,6 +426,7 @@ class MPS:
 
         raise ValueError(f"Unknown bond_policy: {bond_policy!r}")
 
+
     def _create_empty_tensors(self) -> None:
         """Create site tensors with indices [bond_left, physical, bond_right] and data=None."""
         self.tensors = []
@@ -429,10 +434,12 @@ class MPS:
             inds = [self.bonds[i], self.indices[i], self.bonds[i + 1]]
             self.tensors.append(Tensor(None, indices=inds))
 
+
     def _assert_materialized(self) -> None:
         for i, t in enumerate(self.tensors):
             if t.data is None:
                 raise ValueError(f"MPS tensor at site {i} has data=None (unmaterialized MPS)")
+
 
     # -------------------------
     # Python protocol
@@ -441,8 +448,10 @@ class MPS:
     def __len__(self) -> int:
         return self.L
 
+
     def __repr__(self) -> str:
         return f"MPS(L={self.L}, phys_dims={self.physical_dims}, bond_dims={self.bond_dims})"
+
 
     # -------------------------
     # Basic properties
@@ -453,10 +462,12 @@ class MPS:
         """Bond dimensions between sites (including boundaries), length L+1."""
         return [b.dim for b in self.bonds]
 
+
     @property
     def physical_dims(self) -> List[int]:
         """Physical dimension at each site, length L."""
         return [p.dim for p in self.indices]
+
 
     # -------------------------
     # Core linear-algebra helpers
@@ -480,6 +491,7 @@ class MPS:
 
         return float(np.sqrt(np.abs(np.trace(overlap))))
 
+
     def normalize(self) -> "MPS":
         """
         Normalize the MPS in-place so that ⟨ψ|ψ⟩ = 1.
@@ -494,9 +506,6 @@ class MPS:
             self.tensors[0] = self.tensors[0] * (1.0 / nrm)
         return self
 
-    def copy(self) -> "MPS":
-        """Creates a deep copy of the MPS."""
-        return MPS.from_tensors(self.tensors, name=self.name)
 
     def to_dense(self) -> np.ndarray:
         """
@@ -513,3 +522,11 @@ class MPS:
 
         psi = np.squeeze(psi)
         return psi.reshape(-1)
+
+    # -------------------------
+    # External Helpers
+    # -------------------------
+
+    def copy(self) -> "MPS":
+        """Creates a deep copy of the MPS."""
+        return MPS.from_tensors(self.tensors, name=self.name)

--- a/tensor_network_library/core/policy.py
+++ b/tensor_network_library/core/policy.py
@@ -35,7 +35,4 @@ class TruncationPolicy:
             return self.max_bond_dim
 
         return keep_tol
-        
-                
-                
-                
+                 

--- a/tests/core/test_mpo.py
+++ b/tests/core/test_mpo.py
@@ -1,60 +1,204 @@
-#import numpy as np
-#
-#from tensor_network_library.core.mps import MPS
-#from tensor_network_library.core.mpo import MPO
-#
-#def test_identity_mpo_shapes_and_bonds():
-#    L = 10
-#    d = 3
-#    mpo = MPO.identity(L, physical_dims = d)
-#
-#    assert len(mpo) == L
-#
-#    for t in mpo.tensors:
-#        assert t.shape == (1, d, d, 1)
-#
-#    assert mpo.bond_dims == [1] * (L + 1)
-#    assert mpo.physical_dims == [d] * L
-#
-#def test_identity_mpo_applies_as_identity_on_mps():
-#    state = [0, 1, 0]
-#    mps = MPS.from_product_state(state, physical_dims = 2)
-#    mpo = MPO.identity(len(state), physical_dims = 2)
-#
-#    new_mps = mpo.apply(mps)
-#
-#    # bond dims may change (1 -> 1 still here), but state vector should be identical
-#    # For small L, we can reconstruct the full state brute-force.
-#    def to_statevector(mps_obj):
-#        # contract chain explicitly
-#        psi = mps_obj.tensors[0].data[0, :, 0]  # shape (d,)
-#        for t in mps_obj.tensors[1:]:
-#            # t: (1, d, 1), psi: (..., d_prev)
-#            psi = np.tensordot(psi, t.data[0, :, 0], axes=0)  # Kronecker product
-#        return psi.reshape(-1)
-#
-#    psi_original = to_statevector(mps)
-#    psi_new = to_statevector(new_mps)
-#
-#    assert np.allclose(psi_original, psi_new)
-#    
-#def test_mpo_apply_matches_dense():
-#    L = 3
-#    d = 2
-#    state = [1, 1, 0]
-#
-#    mps = MPS.from_product_state(state, physical_dims = d)
-#    mpo = MPO.identity(L, physical_dims = d)  # later you can plug in nontrivial MPO
-#
-#    # Apply with your TN code
-#    mps2 = mpo.apply(mps)
-#
-#    # Dense reference
-#    psi = mps.to_dense()
-#    O = mpo.to_dense()
-#    psi2_dense = O @ psi
-#
-#    # Compare to dense version of mps2
-#    psi2_from_mps = mps2.to_dense()
-#
-#    assert np.allclose(psi2_dense, psi2_from_mps)
+import numpy as np
+import pytest
+
+from tensor_network_library.core.mpo import MPO
+from tensor_network_library.core.mps import MPS
+
+
+def kron_all(ops):
+    out = ops[0]
+    for op in ops[1:]:
+        out = np.kron(out, op)
+    return out
+
+
+def test_mpo_constructor_basic_properties():
+    L = 4
+    d = 2
+    mpo = MPO(L=L, d=d, bond_policy=3)
+
+    assert len(mpo) == L
+    assert mpo.L == L
+    assert mpo.d == d
+    assert mpo.bond_dims == [1, 3, 3, 3, 1]
+    assert mpo.physical_dims == [d] * L
+    assert len(mpo.shape) == L
+
+    for i, tensor in enumerate(mpo.tensors):
+        assert tensor.shape == (mpo.bond_dims[i], d, d, mpo.bond_dims[i + 1])
+
+
+def test_mpo_getitem_returns_site_tensor():
+    mpo = MPO(L=3, d=2, bond_policy=2)
+    assert mpo[0] is mpo.tensors[0]
+    assert mpo[1] is mpo.tensors[1]
+    assert mpo[2] is mpo.tensors[2]
+
+
+def test_identity_mpo_shapes_and_dense():
+    L = 3
+    d = 2
+    mpo = MPO.identity_mpo(L=L, d=d)
+
+    assert len(mpo) == L
+    assert mpo.bond_dims == [1] * (L + 1)
+    assert mpo.physical_dims == [d] * L
+
+    for tensor in mpo.tensors:
+        assert tensor.shape == (1, d, d, 1)
+
+    dense = mpo.to_dense()
+    expected = np.eye(d**L, dtype=np.complex128)
+    assert dense.shape == (d**L, d**L)
+    assert np.allclose(dense, expected)
+
+
+def test_copy_is_deep_copy():
+    mpo = MPO.identity_mpo(L=2, d=2)
+    mpo_copy = mpo.copy()
+
+    assert mpo_copy is not mpo
+    assert mpo_copy.L == mpo.L
+    assert mpo_copy.d == mpo.d
+    assert mpo_copy.bond_dims == mpo.bond_dims
+
+    for t_orig, t_copy in zip(mpo.tensors, mpo_copy.tensors):
+        assert t_copy is not t_orig
+        assert np.allclose(t_copy.data, t_orig.data)
+
+    mpo_copy.tensors[0].data[0, 0, 0, 0] = 7.0
+    assert not np.allclose(mpo_copy.tensors[0].data, mpo.tensors[0].data)
+
+
+def test_initialize_random_preserves_shapes_and_changes_data():
+    mpo = MPO(L=3, d=2, bond_policy=2)
+    before = [t.data.copy() for t in mpo.tensors]
+
+    mpo.initialize_random()
+
+    for t, old in zip(mpo.tensors, before):
+        assert t.shape == old.shape
+        assert t.data.dtype == np.complex128
+        assert not np.allclose(t.data, old)
+
+
+def test_initialize_single_site_operator_dense_matches_expected():
+    L = 3
+    d = 2
+    site = 1
+
+    X = np.array([[0, 1], [1, 0]], dtype=np.complex128)
+
+    mpo = MPO(L=L, d=d, bond_policy=1)
+    mpo.initialize_single_site_operator(X, site=site)
+
+    dense = mpo.to_dense()
+
+    I = np.eye(d, dtype=np.complex128)
+    expected = kron_all([I, X, I])
+
+    assert dense.shape == expected.shape
+    assert np.allclose(dense, expected)
+
+
+def test_initialize_single_site_operator_invalid_shape_raises():
+    mpo = MPO(L=3, d=2, bond_policy=1)
+    bad_op = np.eye(3, dtype=np.complex128)
+
+    with pytest.raises(ValueError, match="Operator shape"):
+        mpo.initialize_single_site_operator(bad_op, site=1)
+
+
+def test_initialize_single_site_operator_invalid_site_raises():
+    mpo = MPO(L=3, d=2, bond_policy=1)
+    X = np.array([[0, 1], [1, 0]], dtype=np.complex128)
+
+    with pytest.raises(ValueError, match="out of range"):
+        mpo.initialize_single_site_operator(X, site=3)
+
+
+def test_to_dense_for_single_site_operator_L1():
+    d = 2
+    Z = np.array([[1, 0], [0, -1]], dtype=np.complex128)
+
+    mpo = MPO(L=1, d=d, bond_policy=1)
+    mpo.initialize_single_site_operator(Z, site=0)
+
+    dense = mpo.to_dense()
+    assert dense.shape == (d, d)
+    assert np.allclose(dense, Z)
+
+
+def test_apply_identity_mpo_returns_same_state_dense():
+    state = [0, 1, 0]
+    d = 2
+
+    mps = MPS.from_product_state(state, physical_dims=d)
+    mpo = MPO.identity_mpo(L=len(state), d=d)
+
+    new_mps = mpo.apply(mps)
+
+    assert np.allclose(new_mps.to_dense(), mps.to_dense())
+
+
+def test_apply_matches_dense_reference_for_single_site_operator():
+    state = [0, 1, 1]
+    d = 2
+    site = 0
+
+    X = np.array([[0, 1], [1, 0]], dtype=np.complex128)
+
+    mps = MPS.from_product_state(state, physical_dims=d)
+
+    mpo = MPO(L=len(state), d=d, bond_policy=1)
+    mpo.initialize_single_site_operator(X, site=site)
+
+    mps_out = mpo.apply(mps)
+
+    psi = mps.to_dense()
+    O = mpo.to_dense()
+    expected = O @ psi
+
+    assert np.allclose(mps_out.to_dense(), expected)
+
+
+def test_apply_length_mismatch_raises():
+    mpo = MPO.identity_mpo(L=3, d=2)
+    mps = MPS.from_product_state([0, 1], physical_dims=2)
+
+    with pytest.raises(ValueError, match="Length mismatch"):
+        mpo.apply(mps)
+
+
+def test_apply_physical_dimension_mismatch_raises():
+    mpo = MPO.identity_mpo(L=3, d=3)
+    mps = MPS.from_product_state([0, 1, 0], physical_dims=2)
+
+    with pytest.raises(ValueError, match="Physical dimension mismatch"):
+        mpo.apply(mps)
+
+
+def test_repr_contains_core_information():
+    mpo = MPO(L=2, d=2, bond_policy=2)
+    rep = repr(mpo)
+
+    assert "MPO" in rep
+    assert "L=2" in rep
+    assert "d=2" in rep
+    assert "shapes=" in rep
+
+
+def test_custom_bond_policy_list_is_respected():
+    bond_dims = [1, 4, 3, 1]
+    mpo = MPO(L=3, d=2, bond_policy=bond_dims)
+
+    assert mpo.bond_dims == bond_dims
+    assert mpo.tensors[0].shape == (1, 2, 2, 4)
+    assert mpo.tensors[1].shape == (4, 2, 2, 3)
+    assert mpo.tensors[2].shape == (3, 2, 2, 1)
+
+
+def test_invalid_bond_policy_length_raises():
+    with pytest.raises(ValueError, match=r"bond_policy list must have length"):
+        MPO(L=3, d=2, bond_policy=[1, 2, 1])
+ 


### PR DESCRIPTION
## Summary
- finalize the MPO implementation in the core tensor-network layer
- add and stabilize `test_mpo.py` coverage for the current MPO API
- complete the MPO/test work needed before moving on to Hamiltonians and DMRG

## Notes
- This PR packages the completed MPO work from `core_development` for merge into `main`.
- The next planned steps are Hamiltonian builders and DMRG on top of the now-tested MPO layer.