### PR TITLE
v2 groundwork: entangled state helpers 1.0.4 → 1.0.5

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -2,6 +2,17 @@
 
 A chronological log of design decisions, bugs found, and milestones reached.
 
+## v1.0.7 • 2026-04-24
+
+## v1.0.6 • 2026-04-23
+
+## v1.0.5 • 2026-04-21
+
+- Added dense statevector helpers for standard entangled state generation (GHZ, Bell, w)
+- Added MPS helpers to generate and initialize entangled states from dense state vectors (Bell, GHZ, w)
+- Added appropriate tests for these above new functions.
+
+---
 
 ## v1.0.3 · 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ The CI badge above reflects the current state of the `main` branch.
 | v1 | Finite-size DMRG — qubit and spin-1/2 bosonic chains | ✅ Done |
 | v2 | TEBD / iTEBD — fermionic and spin-1 environments | 🔲 Planned |
 | v3 | 2D geometries and long-range Hamiltonians | 🔲 Planned |
-| v4+ | Advanced interfaces (AQA, QML, QEC) | 🔲 Exploratory |
 
 See [`ROADMAP.md`](./ROADMAP.md) for detailed per-version task lists and [`DIARY.md`](./DIARY.md) for development notes.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Robust 2-site DMRG for qubit and spin-1/2 bosonic chains.
 
 Real and imaginary time evolution on finite and infinite chains, with fermionic and higher-spin site support.
 
-- [ ] Entangled-state helpers (Bell pair, GHZ)
+- [x] Entangled-state helpers (Bell pair, GHZ)
 - [ ] Truncation schedule presets (per-sweep bond schedules)
 - [ ] `FermionSite` (spin-1/2) and `SpinSite` (spin-1) implementations
 - [ ] Jordan-Wigner string handling for fermionic MPOs

--- a/tensor_network_library/states/entangled_states.py
+++ b/tensor_network_library/states/entangled_states.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from typing import Tuple
+import numpy as np
+
+from tensor_network_library.core.mps import MPS
+
+
+def _basis_index(bits: np.ndarray) -> int:
+    """
+    Map a {0,1}^L bitstring to the corresponding computational-basis index.
+
+    bits[0] is the most significant qubit (leftmost).
+    """
+    bits = np.asarray(bits, dtype=int).reshape(-1)
+    idx = 0
+    for b in bits:
+        if b not in (0, 1):
+            raise ValueError(f"Bits must be 0 or 1, got {b!r}")
+        idx = (idx << 1) | int(b)
+    return idx
+
+
+def _validate_chain(L: int, physical_dims: int) -> None:
+    if L <= 0:
+        raise ValueError("L must be a positive integer.")
+    if physical_dims != 2:
+        # We can support general d later; for TEBD v2 we only need qubits.
+        raise ValueError(
+            "Entangled state helpers currently support qubits only (physical_dims=2)."
+        )
+
+
+def w_statevector(
+    L: int,
+    *,
+    dtype: np.dtype = np.complex128,
+) -> np.ndarray:
+    r"""
+    Dense statevector for the L-qubit W state
+
+        |W_L⟩ = (1/√L) Σ_{k=0}^{L-1} |0…010…0⟩_k,
+
+    i.e., equal superposition of all computational basis states with
+    a single excitation.
+    """
+    _validate_chain(L=L, physical_dims=2)
+
+    dim = 2**L
+    psi = np.zeros(dim, dtype=dtype)
+
+    if L == 0:
+        raise ValueError("Cannot build W-state with L = 0.")
+
+    amp = 1.0 / np.sqrt(float(L))
+
+    bits = np.zeros(L, dtype=int)
+    for k in range(L):
+        bits.fill(0)
+        bits[k] = 1
+        idx = _basis_index(bits)
+        psi[idx] = amp
+
+    return psi.astype(dtype, copy=False)
+
+
+def ghz_statevector(L: int,
+                    *,
+                    dtype: np.dtype = np.complex128,
+                    ) -> np.ndarray:
+    """
+    Dense statevector for the L-qubit GHZ state
+
+        |GHZ_L⟩ = (|0…0⟩ + |1…1⟩) / √2.
+    """
+    
+    _validate_chain(L=L, physical_dims=2)
+
+    dim = 2**L
+    psi = np.zeros(dim, dtype=dtype)
+
+    amp = 1.0 / np.sqrt(2.0)
+
+    bits_zero = np.zeros(L, dtype=int)
+    bits_one = np.ones(L, dtype=int)
+
+    k0 = _basis_index(bits_zero)
+    k1 = _basis_index(bits_one)
+
+    psi[k0] = amp
+    psi[k1] = amp
+
+    return psi.astype(dtype, copy=False)
+
+
+def bell_statevector(L: int = 2,
+                     which: str = "phi+",
+                     pair: Tuple[int, int] = (0, 1), *,
+                     dtype: np.dtype = np.complex128,
+                     ) -> np.ndarray:
+    """
+    Dense statevector for a Bell pair embedded in an L-qubit chain.
+
+    The Bell pair lives on sites `pair = (i, j)`; all other qubits are |0⟩.
+    Sites are 0-based, with site 0 the leftmost qubit.
+
+    Supported `which` labels (case-insensitive):
+
+        "phi+" : (|00⟩ + |11⟩) / √2
+        "phi-" : (|00⟩ - |11⟩) / √2
+        "psi+" : (|01⟩ + |10⟩) / √2
+        "psi-" : (|01⟩ - |10⟩) / √2
+
+    When embedded into an L-site chain, these act on qubits i and j,
+    with all other qubits frozen in |0⟩.
+
+    Returns
+    -------
+    psi : np.ndarray, shape (2**L,)
+        Normalized statevector.
+    """
+    
+    _validate_chain(L = L, physical_dims = 2)
+
+    i, j = pair
+    i = int(i)
+    j = int(j)
+
+    if not (0 <= i < L and 0 <= j < L):
+        raise ValueError(f"pair={pair!r} must have 0 <= i < j < L, got L={L}")
+    if i == j:
+        raise ValueError("Bell pair sites must be distinct.")
+    if i > j:
+        i, j = j, i
+
+    which_key = which.strip().lower()
+    if which_key not in {"phi+", "phi-", "psi+", "psi-"}:
+        raise ValueError(
+            f"Unsupported Bell label {which!r}; "
+            "expected one of 'phi+', 'phi-', 'psi+', 'psi-'."
+        )
+
+    dim = 2**L
+    psi = np.zeros(dim, dtype=dtype)
+
+    bits = np.zeros(L, dtype=int)
+
+    amp = 1.0 / np.sqrt(2.0)
+
+    if which_key.startswith("phi"):
+        # |00> ± |11> on (i,j)
+        # configuration 1: all zeros
+        bits.fill(0)
+        k1 = _basis_index(bits)
+        # configuration 2: ones on i and j
+        bits.fill(0)
+        bits[i] = 1
+        bits[j] = 1
+        k2 = _basis_index(bits)
+
+        if which_key == "phi+":
+            psi[k1] = amp
+            psi[k2] = amp
+        else:  # "phi-"
+            psi[k1] = amp
+            psi[k2] = -amp
+
+    else:
+        # psi±: |01> ± |10> on (i,j)
+        bits.fill(0)
+        bits[i] = 0
+        bits[j] = 1
+        k1 = _basis_index(bits)
+
+        bits.fill(0)
+        bits[i] = 1
+        bits[j] = 0
+        k2 = _basis_index(bits)
+
+        if which_key == "psi+":
+            psi[k1] = amp
+            psi[k2] = amp
+        else:  # "psi-"
+            psi[k1] = amp
+            psi[k2] = -amp
+
+    return psi.astype(dtype, copy=False)
+
+def bell_mps(L: int = 2,
+             which: str = "phi+",
+             pair: Tuple[int, int] = (0, 1), *,
+             name: str = "Bell",
+             dtype: np.dtype = np.complex128,
+             ) -> MPS:
+    """
+    Convenience wrapper: build an MPS for a Bell pair embedded in an L-qubit chain.
+    
+    See 'bell_statevector' for semantics.
+    """
+    
+    psi = bell_statevector(L = L, which = which, pair = pair, dtype=dtype)
+    
+    return MPS.from_statevector(psi,
+                                physical_dims=2,
+                                name = name,
+                                truncation = None,
+                                absorb = "right",
+                                normalize = True,
+                                dtype = dtype,
+                                )
+    
+    
+def ghz_mps(L: int,
+            *,
+            name: str = "GHZ",
+            dtype: np.dtype = np.complex128,
+            ) -> MPS:
+    """
+    Convenience wrapper: build an MPS for the L-qubit GHZ state.
+    """
+    
+    psi = ghz_statevector(L=L, dtype=dtype)
+    
+    return MPS.from_statevector(psi,
+                                physical_dims=2,
+                                name=name,
+                                truncation=None,
+                                absorb="right",
+                                normalize=True,
+                                dtype=dtype,
+                                )
+
+
+def w_mps(L: int,
+          *,
+          name: str = "W",
+          dtype: np.dtype = np.complex128,) -> MPS:
+
+    """
+    Convenience wrapper: build an MPS for the L-qubit W state.
+    """
+    
+    psi = w_statevector(L=L, dtype=dtype)
+    
+    return MPS.from_statevector(psi,
+                                physical_dims=2,
+                                name=name,
+                                truncation=None,
+                                absorb="right",
+                                normalize=True,
+                                dtype=dtype,
+                                )

--- a/tests/states/test_entnagled_states.py
+++ b/tests/states/test_entnagled_states.py
@@ -1,0 +1,156 @@
+# tests/states/test_entangled_states.py
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tensor_network_library.states.entangled_states import (
+    bell_statevector,
+    ghz_statevector,
+    w_statevector,
+    bell_mps,
+    ghz_mps,
+    w_mps,
+)
+from tensor_network_library.core.mps import MPS
+
+
+def _norm(psi: np.ndarray) -> float:
+    return float(np.linalg.norm(np.asarray(psi).reshape(-1)))
+
+
+# ------------------------
+# Dense statevector tests
+# ------------------------
+
+
+@pytest.mark.parametrize("which", ["phi+", "phi-", "psi+", "psi-"])
+def test_bell_statevector_L2_matches_definitions(which: str) -> None:
+    L = 2
+    psi = bell_statevector(L=L, which=which, pair=(0, 1))
+    assert psi.shape == (2**L,)
+    assert np.isclose(_norm(psi), 1.0)
+
+    # Explicit reference definitions on 2 qubits
+    z00 = np.array([1, 0, 0, 0], dtype=np.complex128)
+    z01 = np.array([0, 1, 0, 0], dtype=np.complex128)
+    z10 = np.array([0, 0, 1, 0], dtype=np.complex128)
+    z11 = np.array([0, 0, 0, 1], dtype=np.complex128)
+
+    if which == "phi+":
+        ref = (z00 + z11) / np.sqrt(2.0)
+    elif which == "phi-":
+        ref = (z00 - z11) / np.sqrt(2.0)
+    elif which == "psi+":
+        ref = (z01 + z10) / np.sqrt(2.0)
+    else:  # psi-
+        ref = (z01 - z10) / np.sqrt(2.0)
+
+    assert np.allclose(psi, ref)
+
+
+def test_bell_statevector_embedding_into_longer_chain() -> None:
+    L = 4
+    # Bell pair on the middle sites (1, 2), others in |0>
+    psi = bell_statevector(L=L, which="phi+", pair=(1, 2))
+
+    assert psi.shape == (2**L,)
+    assert np.isclose(_norm(psi), 1.0)
+
+    # Only two basis states should have nonzero amplitudes:
+    # |0000> and |0110>, each with amplitude 1/sqrt(2)
+    amps_nonzero = np.where(np.abs(psi) > 1e-12)[0]
+    assert set(amps_nonzero.tolist()) == {0, 0b0110}
+
+    assert np.allclose(
+        sorted(np.abs(psi[amps_nonzero])),
+        [1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0)],
+    )
+
+
+@pytest.mark.parametrize("L", [2, 3, 5])
+def test_ghz_statevector(L: int) -> None:
+    psi = ghz_statevector(L=L)
+    assert psi.shape == (2**L,)
+    assert np.isclose(_norm(psi), 1.0)
+
+    # Only |0...0> and |1...1> should appear
+    nz = np.where(np.abs(psi) > 1e-12)[0]
+    assert len(nz) == 2
+
+    k0 = 0
+    k1 = (1 << L) - 1
+    assert set(nz.tolist()) == {k0, k1}
+
+    # Amplitudes equal in magnitude
+    mag = np.abs(psi[nz])
+    assert np.allclose(mag[0], mag[1])
+
+
+@pytest.mark.parametrize("L", [2, 3, 5])
+def test_w_statevector(L: int) -> None:
+    psi = w_statevector(L=L)
+    assert psi.shape == (2**L,)
+    assert np.isclose(_norm(psi), 1.0)
+
+    nz = np.where(np.abs(psi) > 1e-12)[0]
+    # There should be exactly L basis states with a single excitation
+    assert len(nz) == L
+
+    # Check that each nonzero configuration has Hamming weight 1
+    for idx in nz:
+        bits = [(idx >> k) & 1 for k in range(L)]
+        assert sum(bits) == 1
+
+    # All nonzero amplitudes have equal magnitude
+    mags = np.abs(psi[nz])
+    assert np.allclose(mags, mags[0])
+
+
+# ------------------------
+# MPS wrapper tests
+# ------------------------
+
+
+def test_bell_mps_to_dense_matches_vector() -> None:
+    L = 4
+    psi = bell_statevector(L=L, which="psi-", pair=(1, 2))
+    mps = bell_mps(L=L, which="psi-", pair=(1, 2))
+
+    assert isinstance(mps, MPS)
+    assert len(mps) == L
+
+    dense = mps.to_dense()
+    # Allow for a possible global phase; compare up to a phase factor
+    phase = dense[0] / psi[0] if np.abs(psi[0]) > 1e-12 else 1.0
+    assert np.allclose(dense, phase * psi)
+
+
+def test_ghz_mps_to_dense_matches_vector() -> None:
+    L = 5
+    psi = ghz_statevector(L=L)
+    mps = ghz_mps(L=L)
+
+    assert isinstance(mps, MPS)
+    assert len(mps) == L
+
+    dense = mps.to_dense()
+    phase = dense[0] / psi[0] if np.abs(psi[0]) > 1e-12 else 1.0
+    assert np.allclose(dense, phase * psi)
+
+
+def test_w_mps_to_dense_matches_vector() -> None:
+    L = 4
+    psi = w_statevector(L=L)
+    mps = w_mps(L=L)
+
+    assert isinstance(mps, MPS)
+    assert len(mps) == L
+
+    dense = mps.to_dense()
+    # W has more nonzero components; estimate phase from first nonzero entry
+    nz = np.where(np.abs(psi) > 1e-12)[0]
+    ref_idx = int(nz[0])
+    phase = dense[ref_idx] / psi[ref_idx]
+    assert np.allclose(dense, phase * psi)


### PR DESCRIPTION
## Summary

Starts the v2 development track by adding the first entangled-state helpers needed for TEBD / iTEBD work, and bumps the patch version.

## Changes

### New module: `tensor_network_library/states/entangled_states.py`

Adds canonical entangled-state helpers:

- `bell_statevector(L, which, pair)` — Bell pair embedded in an L-qubit chain
- `ghz_statevector(L)` — GHZ state `(|0…0⟩ + |1…1⟩) / √2`
- `w_statevector(L)` — W state `(1/√L) Σ_k |0…010…0⟩_k`
- `bell_mps(...)`, `ghz_mps(...)`, `w_mps(...)` — MPS wrappers via `MPS.from_statevector`

### New tests: `tests/states/test_entangled_states.py`

Covers:
- Analytic Bell-state definitions for all four Bell states
- Bell-pair embedding into longer chains (nonzero-index check)
- GHZ normalization and support
- W-state normalization and Hamming-weight check
- MPS-to-dense roundtrip up to global phase

### Version

Bumps `pyproject.toml` version `1.0.4` → `1.0.5`.

## Why

First implementation step toward the v2 TEBD / iTEBD milestone. These helpers provide clean, physically canonical benchmark states for:
- two-site gate application tests
- norm conservation checks
- entanglement-growth benchmarks
- future TEBD regression tests

## Next steps

- Two-site gate application helpers on MPS
- Finite TEBD stepper
- Additional site types (`FermionSite`, `SpinSite`)